### PR TITLE
FIX: Activate script fix for Windows and *nix systems.

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -9,4 +9,4 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 2.7.* *_cpython
+- 3.6.* *_cpython

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About pydm
 
 Home: https://github.com/slaclab/pydm
 
-Package license: SLAC Open
+Package license: LicenseRef-BSD-3-Clause-SLAC
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
-

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,7 +19,7 @@ echo "unset PYQTDESIGNERPATH" >> $DEACTIVATE.sh
 
 echo '@echo OFF' >> $ACTIVATE.bat
 echo 'IF "%PYQTDESIGNERPATH%" == "" (' >> $ACTIVATE.bat
-echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pydm;' >> $ACTIVATE.bat
+echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pydm' >> $ACTIVATE.bat
 echo ')ELSE (' >> $ACTIVATE.bat
 echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pydm;%PYQTDESIGNERPATH%' >> $ACTIVATE.bat
 echo ')' >> $ACTIVATE.bat

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,15 +9,22 @@ mkdir -p $PREFIX/etc/pydm
 # Create auxiliary vars
 DESIGNER_PLUGIN_PATH=$PREFIX/etc/pydm
 DESIGNER_PLUGIN=$DESIGNER_PLUGIN_PATH/pydm_designer_plugin.py
-ACTIVATE=$PREFIX/etc/conda/activate.d/pydm.sh
-DEACTIVATE=$PREFIX/etc/conda/deactivate.d/pydm.sh
+ACTIVATE=$PREFIX/etc/conda/activate.d/pydm
+DEACTIVATE=$PREFIX/etc/conda/deactivate.d/pydm
 
 echo "from pydm.widgets.qtplugins import *" >> $DESIGNER_PLUGIN
-echo "export PYQTDESIGNERPATH="$DESIGNER_PLUGIN_PATH":\$PYQTDESIGNERPATH" >> $ACTIVATE
-echo "unset PYQTDESIGNERPATH" >> $DEACTIVATE
+
+echo "export PYQTDESIGNERPATH=\$CONDA_PREFIX/etc/pydm:\$PYQTDESIGNERPATH" >> $ACTIVATE.sh
+echo "unset PYQTDESIGNERPATH" >> $DEACTIVATE.sh
+
+echo '@echo OFF' >> $ACTIVATE.bat
+echo 'IF "%PYQTDESIGNERPATH%" == "" (' >> $ACTIVATE.bat
+echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pydm;' >> $ACTIVATE.bat
+echo ')ELSE (' >> $ACTIVATE.bat
+echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pydm;%PYQTDESIGNERPATH%' >> $ACTIVATE.bat
+echo ')' >> $ACTIVATE.bat
 
 unset DESIGNER_PLUGIN_PATH
 unset DESIGNER_PLUGIN
 unset ACTIVATE
 unset DEACTIVATE
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   entry_points:
     - pydm = pydm_launcher.main:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ test:
 
 about:
   home: https://github.com/slaclab/pydm 
-  license: SLAC Open
+  license: LicenseRef-BSD-3-Clause-SLAC
   license_family: OTHER
   license_file: LICENSE.md
   summary: 'Python Display Manager'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/slaclab/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 770cd76f3d5fe9bc27594e68d6f88d3b77e764892115accf7dbfe09e38c52509
+  sha256: d92561638549749d378c452375357c8d1e659ce31cdd0ad2a256a0a9f51741de
 
 build:
   noarch: python


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

## Changes
- Delay expansion of `CONDA_PREFIX` until the script is used. This avoids the issue in which users get the wrong path for the designer plugin file.
- Address issue with Windows in which the PYQTDESIGNERPATH was not being set due to lack of pydm.bat file.