### PR TITLE
Fix the `PYQTDESIGNERPATH: unbound variable` issue

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -vxeuo pipefail
+
 # Install the package
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - pydm = pydm_launcher.main:main
 
@@ -36,6 +36,10 @@ requirements:
 test:
   imports:
     - pydm
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/slaclab/pydm


### PR DESCRIPTION
During packaging an environment with `pydm` in it, we observed the following issue:
```bash
...
if [ -d "${CONDA_PREFIX}/share/proj" ]; then
  export "PROJ_LIB=${CONDA_PREFIX}/share/proj"
elif [ -d "${CONDA_PREFIX}/Library/share/proj" ]; then
  export PROJ_LIB="${CONDA_PREFIX}/Library/share/proj"
fi
+++ '[' -d /opt/conda_envs/nsls2-collection-2021-2.0/share/proj ']'
+++ export PROJ_LIB=/opt/conda_envs/nsls2-collection-2021-2.0/share/proj
+++ PROJ_LIB=/opt/conda_envs/nsls2-collection-2021-2.0/share/proj

if [ -f "${CONDA_PREFIX}/share/proj/copyright_and_licenses.csv" ]; then
  # proj-data is installed because its license was copied over
  export PROJ_NETWORK="OFF"
else
  export PROJ_NETWORK="ON"
fi
+++ '[' -f /opt/conda_envs/nsls2-collection-2021-2.0/share/proj/copyright_and_licenses.csv ']'
+++ export PROJ_NETWORK=ON
+++ PROJ_NETWORK=ON
. "/opt/conda_envs/nsls2-collection-2021-2.0/etc/conda/activate.d/pydm.sh"
++ . /opt/conda_envs/nsls2-collection-2021-2.0/etc/conda/activate.d/pydm.sh
export PYQTDESIGNERPATH=$CONDA_PREFIX/etc/pydm:$PYQTDESIGNERPATH
/opt/conda_envs/nsls2-collection-2021-2.0/etc/conda/activate.d/pydm.sh: line 1: PYQTDESIGNERPATH: unbound variable
```
In this PR I am adding more checks to capture it earlier.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
