### PR TITLE
Update recipe to use python 3.6+ and the versions of PyQt5 that currently work with PyDM

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/slaclab/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: b89eab831a2e420fc2b16a8b2848195e448f6239bfa2fbc72b8e7de416730fb7
+  sha256: b32e6bc81fb5900c951633a76a6bfce7827323289aed0dc467372e4397fc83f7
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,25 +11,25 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - pydm = pydm_launcher.main:main
 
 requirements:
   host:
-    - python >=2.7
+    - python >=3.6
     - pip
     - setuptools
-    - pyqt >=5
+    - pyqt >=5,<5.15
     - qtpy
   run:
-    - python >=2.7
+    - python >=3.6
     - six
     - numpy
     - scipy
     - pyepics
     - requests
-    - pyqt >=5
+    - pyqt >=5,<5.15
     - pyqtgraph
     - qtpy
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Support for python 2 was dropped previously, this is now reflected here. And currently PyQt5 5.15 does not play well with PyDM. Once all issues with 5.15 are resolved, >5 will be allowed again.
