### PR TITLE
Update build.sh to match the one from the main PyDM repo with pyside6 support

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,5 @@
 # Install the package
-$PYTHON -m pip install . -vv
+$PYTHON -m pip install . --no-deps -vv
 
 # Create auxiliary dirs
 mkdir -p $PREFIX/etc/conda/activate.d
@@ -8,20 +8,27 @@ mkdir -p $PREFIX/etc/pydm
 
 # Create auxiliary vars
 DESIGNER_PLUGIN_PATH=$PREFIX/etc/pydm
-DESIGNER_PLUGIN=$DESIGNER_PLUGIN_PATH/pydm_designer_plugin.py
+DESIGNER_PLUGIN=$DESIGNER_PLUGIN_PATH/register_pydm_designer_plugin.py
 ACTIVATE=$PREFIX/etc/conda/activate.d/pydm
 DEACTIVATE=$PREFIX/etc/conda/deactivate.d/pydm
 
-echo "from pydm.widgets.qtplugins import *" >> $DESIGNER_PLUGIN
+cat ./pydm/register_pydm_designer_plugin.py >> $DESIGNER_PLUGIN
 
 echo "export PYQTDESIGNERPATH=\$CONDA_PREFIX/etc/pydm:\$PYQTDESIGNERPATH" >> $ACTIVATE.sh
+echo "export PYSIDE_DESIGNER_PLUGINS=\$CONDA_PREFIX/etc/pydm:\$PYSIDE_DESIGNER_PLUGINS" >> $ACTIVATE.sh
 echo "unset PYQTDESIGNERPATH" >> $DEACTIVATE.sh
+echo "unset PYSIDE_DESIGNER_PLUGINS" >> $DEACTIVATE.sh
 
 echo '@echo OFF' >> $ACTIVATE.bat
 echo 'IF "%PYQTDESIGNERPATH%" == "" (' >> $ACTIVATE.bat
 echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pydm' >> $ACTIVATE.bat
 echo ')ELSE (' >> $ACTIVATE.bat
 echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pydm;%PYQTDESIGNERPATH%' >> $ACTIVATE.bat
+echo ')' >> $ACTIVATE.bat
+echo 'IF "%PYSIDE_DESIGNER_PLUGINS%" == "" (' >> $ACTIVATE.bat
+echo 'set PYSIDE_DESIGNER_PLUGINS=%CONDA_PREFIX%\etc\pydm' >> $ACTIVATE.bat
+echo ')ELSE (' >> $ACTIVATE.bat
+echo 'set PYSIDE_DESIGNER_PLUGINS=%CONDA_PREFIX%\etc\pydm;%PYSIDE_DESIGNER_PLUGINS%' >> $ACTIVATE.bat
 echo ')' >> $ACTIVATE.bat
 
 unset DESIGNER_PLUGIN_PATH

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - pydm = pydm_launcher.main:main
 


### PR DESCRIPTION
Updates to match this `build.sh` file which has been tested to work properly with both PyQt5 and Pyside6:

https://github.com/slaclab/pydm/blob/master/conda-recipe/build.sh

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
